### PR TITLE
Feat/audio req from memory

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -57,7 +57,6 @@ func (c *Client) callAudioAPI(
 	if err = audioMultipartForm(request, w); err != nil {
 		return
 	}
-	
 
 	urlSuffix := fmt.Sprintf("/audio/%s", endpointSuffix)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.fullURL(urlSuffix), &formBody)


### PR DESCRIPTION
Allow requests to Whisper using audio files stored in memory (e.g., uploaded from a POST endpoint)